### PR TITLE
nodeinfo 重复设置问题

### DIFF
--- a/chain/core/node.go
+++ b/chain/core/node.go
@@ -86,14 +86,17 @@ func NewNode(conf *viper.Viper, runtime, appName string) (*Node, error) {
 	newAngine.SetQueryPayLoadTxParser(queryPayLoadTxParser)
 
 	newAngine.ConnectApp(initApp)
-
+	nodeinfo := newAngine.GetNodeInfo()
+	if nodeinfo == nil {
+		nodeinfo = makeNodeInfo(conf, newAngine.PrivValidator().PubKey, newAngine.P2PHost(), newAngine.P2PPort())
+	}
 	node := &Node{
 		Application: initApp,
 		Angine:      newAngine,
 		AngineTune:  tune,
 		GenesisDoc:  newAngine.Genesis(),
 
-		nodeInfo:      makeNodeInfo(conf, newAngine.PrivValidator().PubKey, newAngine.P2PHost(), newAngine.P2PPort()),
+		nodeInfo:      nodeinfo,
 		config:        conf,
 		privValidator: newAngine.PrivValidator(),
 	}


### PR DESCRIPTION
angine初始化的时候，会调用prepareP2P对Switch调用p2psw.SetNodeInfo，即设置过了nodeinfo；在node中，RegisterNodeInfo会再次将Switch的nodeinfo覆盖了