### PR TITLE
nodeinfo 重复设置

### DIFF
--- a/chain/core/node.go
+++ b/chain/core/node.go
@@ -86,20 +86,18 @@ func NewNode(conf *viper.Viper, runtime, appName string) (*Node, error) {
 	newAngine.SetQueryPayLoadTxParser(queryPayLoadTxParser)
 
 	newAngine.ConnectApp(initApp)
-
 	node := &Node{
 		Application: initApp,
 		Angine:      newAngine,
 		AngineTune:  tune,
 		GenesisDoc:  newAngine.Genesis(),
 
-		nodeInfo:      makeNodeInfo(conf, newAngine.PrivValidator().PubKey, newAngine.P2PHost(), newAngine.P2PPort()),
+		nodeInfo:      newAngine.GetNodeInfo(),
 		config:        conf,
 		privValidator: newAngine.PrivValidator(),
 	}
 	vm.DefaultAdminContract.SetCallback(node.ExecAdminTx)
 	// newAngine.SetAdminVoteRPC(node.GetAdminVote)
-	newAngine.RegisterNodeInfo(node.nodeInfo)
 	initApp.SetCore(newAngine)
 
 	return node, nil

--- a/gemmill/angine.go
+++ b/gemmill/angine.go
@@ -150,7 +150,7 @@ func NewAngine(app types.Application, tune *Tunes) (angine *Angine, err error) {
 
 	logger, err := getLogger(conf)
 	if err != nil {
-		err  = fmt.Errorf("failed to get logger: %v", err)
+		err = fmt.Errorf("failed to get logger: %v", err)
 		return nil, err
 	}
 	log.SetLog(logger)
@@ -163,13 +163,13 @@ func NewAngine(app types.Application, tune *Tunes) (angine *Angine, err error) {
 	crypto.NodeInit(crypto.CryptoType)
 	privValidator, err := types.LoadPrivValidator(conf.GetString("priv_validator_file"))
 	if err != nil {
-		err  = fmt.Errorf("LoadPrivValidator error: %v", err)
+		err = fmt.Errorf("LoadPrivValidator error: %v", err)
 		return nil, err
 	}
 	refuseList = refuse_list.NewRefuseList(dbBackend, dbDir)
 	p2psw, err := prepareP2P(conf, genesis, privValidator, refuseList)
 	if err != nil {
-		err  = fmt.Errorf("prepare p2p error: %v", err)
+		err = fmt.Errorf("prepare p2p error: %v", err)
 		return nil, err
 	}
 
@@ -231,7 +231,7 @@ func (a *Angine) OnRecvExchangeData(data *p2p.ExchangeData) error {
 		a.p2pSwitch.GetExchangeData().GenesisJSON = data.GenesisJSON
 		if err = a.buildState(otherGenesis); err != nil {
 			// TODO log err
-			log.Warn("build state err:",  zap.Error(err))
+			log.Warn("build state err:", zap.Error(err))
 			return err
 		}
 		if a.stateMachine == nil {
@@ -344,7 +344,7 @@ func (ang *Angine) assembleStateMachine(stateM *state.State) {
 	var addrBook *p2p.AddrBook
 	if conf.GetBool("pex_reactor") {
 		addrBook = p2p.NewAddrBook(conf.GetString("addrbook_file"), conf.GetBool("addrbook_strict"))
-		pexReactor := p2p.NewPEXReactor(addrBook)
+		pexReactor := p2p.NewPEXReactor(addrBook, conf.GetString("p2p_proxy_addr"))
 		ang.p2pSwitch.AddReactor("PEX", pexReactor)
 	}
 
@@ -1131,11 +1131,12 @@ func prepareP2P(conf *viper.Viper, genesis *types.GenesisDoc, privValidator *typ
 		return nil, errors.Wrap(err, "prepareP2P")
 	}
 	nodeInfo := &p2p.NodeInfo{
-		PubKey:      privValidator.GetPubKey(),
-		SigndPubKey: conf.GetString("signbyCA"),
-		Moniker:     conf.GetString("moniker"),
-		ListenAddr:  defaultListener.ExternalAddress().String(),
-		Version:     version,
+		PubKey:       privValidator.GetPubKey(),
+		SigndPubKey:  conf.GetString("signbyCA"),
+		Moniker:      conf.GetString("moniker"),
+		ListenAddr:   defaultListener.ExternalAddress().String(),
+		P2pProxyAddr: conf.GetString("p2p_proxy_addr"),
+		Version:      version,
 	}
 	privKey := privValidator.GetPrivKey()
 	p2psw.AddListener(defaultListener)

--- a/gemmill/config/config.go
+++ b/gemmill/config/config.go
@@ -194,6 +194,7 @@ func SetDefaults(runtime string, conf *viper.Viper) *viper.Viper {
 	conf.SetDefault("db_archive_dir", path.Join(runtime, ARCHIVEDIR))
 	conf.SetDefault("revision_file", path.Join(runtime, "revision"))
 	conf.SetDefault("filter_peers", false)
+	conf.SetDefault("p2p_proxy_addr", "")
 
 	setMempoolDefaults(conf)
 	setConsensusDefaults(conf)

--- a/gemmill/p2p/types.go
+++ b/gemmill/p2p/types.go
@@ -26,14 +26,15 @@ import (
 const maxNodeInfoSize = 10240 // 10Kb
 
 type NodeInfo struct {
-	PubKey      crypto.PubKey `json:"pub_key"`
-	SigndPubKey string        `json:"signd_pub_key"`
-	Moniker     string        `json:"moniker"`
-	Network     string        `json:"network"`
-	RemoteAddr  string        `json:"remote_addr"`
-	ListenAddr  string        `json:"listen_addr"`
-	Version     string        `json:"version"` // major.minor.revision
-	Other       []string      `json:"other"`   // other application specific data
+	PubKey       crypto.PubKey `json:"pub_key"`
+	SigndPubKey  string        `json:"signd_pub_key"`
+	Moniker      string        `json:"moniker"`
+	Network      string        `json:"network"`
+	RemoteAddr   string        `json:"remote_addr"`
+	ListenAddr   string        `json:"listen_addr"`
+	P2pProxyAddr string        `json:"p2p_proxy_addr"`
+	Version      string        `json:"version"` // major.minor.revision
+	Other        []string      `json:"other"`   // other application specific data
 }
 
 type ExchangeData struct {


### PR DESCRIPTION
angine初始化的时候，会调用prepareP2P对Switch调用p2psw.SetNodeInfo，即设置过了nodeinfo；在node中，RegisterNodeInfo会再次将Switch的nodeinfo覆盖了